### PR TITLE
Fix crash when no images on SD card.

### DIFF
--- a/sw-frontpanel/main/json_stream.cpp
+++ b/sw-frontpanel/main/json_stream.cpp
@@ -156,6 +156,11 @@ esp_err_t JsonStreamWriter::write(const char* key, const char* value) {
     if (ret != ESP_OK) return ret;
 
     first_item_ = true; // Reset for the value
+    if (value == nullptr) {
+        esp_err_t null_ret = writeSeparator();
+        if (null_ret != ESP_OK) return null_ret;
+        return sendChunk("null");
+    }
     return writeString(value);
 }
 


### PR DESCRIPTION
```json
{"current_path":"/","current_image":<null crash>
```
```
I (13262) host_comm: Current path: /
I (13262) host_comm: Getting loaded image status
I (13272) host_comm: Image status: loaded=0, name=
Guru Meditation Error: Core  0 panic'ed (Load access fault). Exception was unhandled.

--- Stack dump detected
Core  0 register dump:
MEPC    : 0x4201495a  RA      : 0x420136b6  SP      : 0x3fcbe190  GP      : 0x3fc97400
--- 0x4201495a: JsonStreamWriter::sendEscapedString(char const*) at
/home/eric/source/open-retro-storage-frontpanel/sw-frontpanel/main/json_stream.cpp:33
--- 0x420136b6: api_images_handler(httpd_req*) at
/home/eric/source/open-retro-storage-frontpanel/sw-frontpanel/main/web_server.cpp:224
```

Fixed
```json
{"current_path":"/","current_image":null,"image_index":0,"total_images":0,"entries":[]}
```