### PR TITLE
Reduce firmware size

### DIFF
--- a/sw-frontpanel/main/ui_screens.c
+++ b/sw-frontpanel/main/ui_screens.c
@@ -899,18 +899,18 @@ static const char* initiator_device_type_str(uint8_t device_type) {
     }
 }
 
-/* Human-readable size. Everything is cast to unsigned long long because
- * `long` is 32-bit on the ESP32 and these are 64-bit byte counts. */
+/* Human-readable size. The 64-bit byte count is reduced to a 32-bit KiB count
+ * before formatting: the nano printf this firmware links against has no 64-bit
+ * conversions, and 32 bits of KiB covers everything up to 4 TB. */
 static void format_size(char *buf, size_t buf_size, uint64_t bytes) {
-    const uint64_t gib = (uint64_t)1024 * 1024 * 1024;
-    if (bytes >= gib) {
-        snprintf(buf, buf_size, "%llu.%llu GB",
-                 (unsigned long long)(bytes / gib),
-                 (unsigned long long)((bytes % gib) * 10 / gib));
-    } else if (bytes >= 1024 * 1024) {
-        snprintf(buf, buf_size, "%llu MB", (unsigned long long)(bytes / (1024 * 1024)));
+    const unsigned long mib = 1024 * 1024;
+    unsigned long kib = (unsigned long)(bytes / 1024);
+    if (kib >= mib) {  // >= 1GB
+        snprintf(buf, buf_size, "%lu.%lu GB", kib / mib, (kib % mib) * 10 / mib);
+    } else if (kib >= 1024) { // >= 1MB
+        snprintf(buf, buf_size, "%lu MB", kib / 1024);
     } else {
-        snprintf(buf, buf_size, "%llu KB", (unsigned long long)(bytes / 1024));
+        snprintf(buf, buf_size, "%lu KB", kib);
     }
 }
 
@@ -952,7 +952,7 @@ static void initiator_trim(char *dst, size_t dst_size, const char *src, size_t s
 static void initiator_fit_filename(char *dst, size_t dst_size, const char *name, int max_chars) {
     int len = (int)strlen(name);
     if (len <= max_chars) {
-        snprintf(dst, dst_size, "%s", name);
+        strlcpy(dst, name, dst_size);
     } else {
         snprintf(dst, dst_size, "\xe2\x80\xa6%s", name + (len - max_chars + 1));
     }

--- a/sw-frontpanel/sdkconfig.defaults
+++ b/sw-frontpanel/sdkconfig.defaults
@@ -39,8 +39,5 @@ CONFIG_LOG_MAXIMUM_LEVEL_WARN=y
 # The panel is IPv4-only (mDNS and the web UI both work over IPv4). (~28 KB)
 CONFIG_LWIP_IPV6=n
 
-# No esp_err_t name table; errors log as numeric codes. (~8 KB)
-CONFIG_ESP_ERR_TO_NAME_LOOKUP=n
-
 # WPA2/3-Enterprise is not supported by the WiFi setup UI.
 CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT=n

--- a/sw-frontpanel/sdkconfig.defaults
+++ b/sw-frontpanel/sdkconfig.defaults
@@ -17,3 +17,30 @@ CONFIG_HTTPD_MAX_URI_LEN=512
 
 # OTA rollback support
 CONFIG_APP_ROLLBACK_ENABLE=y
+
+# Image size reduction. The app partition is 1.5 MB, but a smaller image also
+# means faster OTA transfers and a smaller PicoIDE bundle.
+
+# Optimize for size rather than the IDF default -Og. (~99 KB)
+CONFIG_COMPILER_OPTIMIZATION_SIZE=y
+
+# Compile out assert() (~62 KB). Failures become undefined behavior instead of
+# than a logged abort, so revert this first when trying to repro issues.
+CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE=y
+
+# Reduced-footprint printf (~25 KB). Drops float/long-long formatting not used
+# by this firmware.
+CONFIG_NEWLIB_NANO_FORMAT=y
+
+# Ship warnings and errors only; drops the INFO-level format strings (~23 KB).
+CONFIG_LOG_DEFAULT_LEVEL_WARN=y
+CONFIG_LOG_MAXIMUM_LEVEL_WARN=y
+
+# The panel is IPv4-only (mDNS and the web UI both work over IPv4). (~28 KB)
+CONFIG_LWIP_IPV6=n
+
+# No esp_err_t name table; errors log as numeric codes. (~8 KB)
+CONFIG_ESP_ERR_TO_NAME_LOOKUP=n
+
+# WPA2/3-Enterprise is not supported by the WiFi setup UI.
+CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT=n


### PR DESCRIPTION
Reduces firmware for default builds by ~237kB by:

- Compiling with `-Os` (which actually optimizes more than esp-idf's default of `-Og`)
- Removing runtime assertions
- Using nano printf, which doesn't support float or long-long, not used in the firmware currently
- Dropping INFO level prints and higher
- Dropping IPv6
- Dropping enterprise WiFi support

A lot of these are dropped because they're never visible to end users because the UART is not really usable anyway.