### PR TITLE
Only commit FW upgrade if we can talk to the main board if upgrade came from the main board

### DIFF
--- a/sw-frontpanel/main/main.c
+++ b/sw-frontpanel/main/main.c
@@ -2544,11 +2544,28 @@ void app_main(void) {
 
     ESP_LOGI(TAG, "System initialized successfully");
 
-    // If we booted from a new OTA firmware, mark it as valid now that init succeeded
+    // If we booted from a new OTA firmware
+    ota_update_source_t ota_source = ota_manager_take_update_source();
     const esp_partition_t *running = esp_ota_get_running_partition();
     esp_ota_img_states_t ota_state;
     if (esp_ota_get_state_partition(running, &ota_state) == ESP_OK) {
         if (ota_state == ESP_OTA_IMG_PENDING_VERIFY) {
+            if (ota_source == OTA_SOURCE_HOST &&
+                // If the new firmware came from the main board, rollback if we can't
+                // talk to the main board. The main board stays up during an OTA update
+                // driven by it, so it should be immediately available for the aliveness
+                // check.
+                (host_comm_probe_alive(&host_comm, 0) != ESP_OK ||
+                 host_comm_probe_alive(&host_comm, 0) != ESP_OK)) {
+                ESP_LOGE(TAG, "New firmware came from the main board but the main board is not responding; rolling back");
+                ui_draw_firmware_update(&display, "No main board, rolling back", 0);
+                led_set_color(COLOR_RED);
+                vTaskDelay(pdMS_TO_TICKS(3000));
+                esp_err_t rb_ret = esp_ota_mark_app_invalid_rollback_and_reboot();
+                // Only returns if there is no valid image to roll back to, in
+                // which case this image is all we have, so keep it.
+                ESP_LOGW(TAG, "Rollback not possible (%s), keeping new firmware", esp_err_to_name(rb_ret));
+            }
             ESP_LOGI(TAG, "New firmware verified successfully, cancelling rollback");
             esp_ota_mark_app_valid_cancel_rollback();
         }

--- a/sw-frontpanel/main/ota_manager.c
+++ b/sw-frontpanel/main/ota_manager.c
@@ -19,6 +19,8 @@
 #include "esp_log.h"
 #include "esp_system.h"
 #include "esp_app_desc.h"
+#include "nvs_flash.h"
+#include "nvs.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "mbedtls/sha256.h"
@@ -334,6 +336,10 @@ esp_err_t ota_manager_process(ota_manager_t* ota) {
             return ret;
         }
 
+        // Remember this image came via the main board so the next boot can
+        // insist on working host comms before committing to it.
+        ota_manager_set_update_source(OTA_SOURCE_HOST);
+
         // Version will be automatically updated in esp_app_desc_t after restart
 
         ota->state = OTA_STATE_SUCCESS;
@@ -439,6 +445,41 @@ esp_err_t ota_manager_abort(ota_manager_t* ota) {
 
     ota->state = OTA_STATE_IDLE;
     return ESP_OK;
+}
+
+#define OTA_NVS_NAMESPACE "ota"
+#define OTA_NVS_KEY_SOURCE "src"
+
+esp_err_t ota_manager_set_update_source(ota_update_source_t source) {
+    nvs_handle_t handle;
+    esp_err_t ret = nvs_open(OTA_NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to open NVS to record update source: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    ret = nvs_set_u8(handle, OTA_NVS_KEY_SOURCE, (uint8_t)source);
+    if (ret == ESP_OK) {
+        ret = nvs_commit(handle);
+    }
+    nvs_close(handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to record update source: %s", esp_err_to_name(ret));
+    }
+    return ret;
+}
+
+ota_update_source_t ota_manager_take_update_source(void) {
+    nvs_handle_t handle;
+    if (nvs_open(OTA_NVS_NAMESPACE, NVS_READWRITE, &handle) != ESP_OK) {
+        return OTA_SOURCE_NONE;
+    }
+    uint8_t value = OTA_SOURCE_NONE;
+    if (nvs_get_u8(handle, OTA_NVS_KEY_SOURCE, &value) == ESP_OK) {
+        nvs_erase_key(handle, OTA_NVS_KEY_SOURCE);
+        nvs_commit(handle);
+    }
+    nvs_close(handle);
+    return (ota_update_source_t)value;
 }
 
 esp_err_t ota_manager_mark_valid(void) {

--- a/sw-frontpanel/main/ota_manager.h
+++ b/sw-frontpanel/main/ota_manager.h
@@ -90,6 +90,21 @@ esp_err_t ota_manager_abort(ota_manager_t* ota);
 // Mark current firmware as valid (call after successful boot)
 esp_err_t ota_manager_mark_valid(void);
 
+// Where the pending OTA image came from. Persisted in NVS across the reboot
+// into the new image so boot-time validation can decide what to require
+// before cancelling rollback.
+typedef enum {
+    OTA_SOURCE_NONE = 0,
+    OTA_SOURCE_HOST = 1,    // Fetched from the main board (host_comm)
+    OTA_SOURCE_DIRECT = 2   // Uploaded directly (e.g. web upload)
+} ota_update_source_t;
+
+// Record the source of the image that was just written and set as boot partition
+esp_err_t ota_manager_set_update_source(ota_update_source_t source);
+
+// Read and clear the recorded source (returns OTA_SOURCE_NONE if not set)
+ota_update_source_t ota_manager_take_update_source(void);
+
 // Get current firmware version
 uint32_t ota_manager_get_current_version(void);
 

--- a/sw-frontpanel/main/web_server.cpp
+++ b/sw-frontpanel/main/web_server.cpp
@@ -2227,6 +2227,8 @@ static esp_err_t api_panel_firmware_upload_handler(httpd_req_t *req) {
         return ESP_FAIL;
     }
 
+    ota_manager_set_update_source(OTA_SOURCE_DIRECT);
+
     ESP_LOGI(TAG, "Panel firmware uploaded (%u bytes), rebooting", bytes_written);
 
     httpd_resp_set_type(req, "application/json");


### PR DESCRIPTION
On PicoIDE, the front panel is only updated from firmware that comes from the SD card in the main board. Only commit the upgrade if we can talk to the main board after rebooting with the new firmware. This is important because the front panel is not trivially reflashable like the main board is, so we need to make sure our only update mechanism still works before we commit.

On BlueSCSI, the firmware is uploaded/downloaded directly so it sets `OTA_SOURCE_DIRECT` and commits immediately after rebooting.